### PR TITLE
Update docs and add run await for Crystal client

### DIFF
--- a/src/SnD.ApiClient/Base/SndApiClient.cs
+++ b/src/SnD.ApiClient/Base/SndApiClient.cs
@@ -16,7 +16,7 @@ public abstract class SndApiClient
     
     private readonly HttpClient httpClient;
     private readonly IJwtTokenExchangeProvider boxerConnector;
-    private readonly ILogger logger;
+    protected readonly ILogger logger;
     private string boxerToken;
 
     protected SndApiClient(HttpClient httpClient, IJwtTokenExchangeProvider boxerConnector, ILogger logger)

--- a/src/SnD.ApiClient/Config/CrystalClientOptions.cs
+++ b/src/SnD.ApiClient/Config/CrystalClientOptions.cs
@@ -12,9 +12,4 @@ public class CrystalClientOptions
     /// Api version
     /// </summary>
     public string ApiVersion { get; set; }
-    
-    /// <summary>
-    /// Maximum retries before giving up on 404 responses.
-    /// </summary>
-    public int MaxRetries { get; set; }
 }

--- a/src/SnD.ApiClient/Config/CrystalClientOptions.cs
+++ b/src/SnD.ApiClient/Config/CrystalClientOptions.cs
@@ -12,4 +12,9 @@ public class CrystalClientOptions
     /// Api version
     /// </summary>
     public string ApiVersion { get; set; }
+    
+    /// <summary>
+    /// Maximum retries before giving up on 404 responses.
+    /// </summary>
+    public int MaxRetries { get; set; }
 }

--- a/src/SnD.ApiClient/Crystal/Base/ICrystalClient.cs
+++ b/src/SnD.ApiClient/Crystal/Base/ICrystalClient.cs
@@ -33,8 +33,8 @@ public interface ICrystalClient
     /// </summary>
     /// <param name="algorithm">Algorithm name</param>
     /// <param name="requestId">Request ID received form <see cref="CreateRunAsync"/></param>
-    /// <param name="cancellationToken">Cancellation token</param>
+    /// <param name="cancellationToken">Cancellation token for the operation timeout.</param>
+    /// <param name="pollIntervalSeconds">Poll interval to check for run results in seconds.</param>
     /// <returns>RunResult instance</returns>
-    public Task<RunResult> AwaitRunAsync(string algorithm, string requestId,
-        CancellationToken cancellationToken = default);
+    public Task<RunResult> AwaitRunAsync(string algorithm, string requestId, CancellationToken cancellationToken, int pollIntervalSeconds);
 }

--- a/src/SnD.ApiClient/Crystal/Base/ICrystalClient.cs
+++ b/src/SnD.ApiClient/Crystal/Base/ICrystalClient.cs
@@ -34,7 +34,7 @@ public interface ICrystalClient
     /// <param name="algorithm">Algorithm name</param>
     /// <param name="requestId">Request ID received form <see cref="CreateRunAsync"/></param>
     /// <param name="cancellationToken">Cancellation token for the operation timeout.</param>
-    /// <param name="pollIntervalSeconds">Poll interval to check for run results in seconds.</param>
+    /// <param name="pollInterval">Poll interval to check for run results.</param>
     /// <returns>RunResult instance</returns>
-    public Task<RunResult> AwaitRunAsync(string algorithm, string requestId, CancellationToken cancellationToken = default, int pollIntervalSeconds = 1);
+    public Task<RunResult> AwaitRunAsync(string algorithm, string requestId, TimeSpan pollInterval, CancellationToken cancellationToken);
 }

--- a/src/SnD.ApiClient/Crystal/Base/ICrystalClient.cs
+++ b/src/SnD.ApiClient/Crystal/Base/ICrystalClient.cs
@@ -36,5 +36,5 @@ public interface ICrystalClient
     /// <param name="cancellationToken">Cancellation token for the operation timeout.</param>
     /// <param name="pollIntervalSeconds">Poll interval to check for run results in seconds.</param>
     /// <returns>RunResult instance</returns>
-    public Task<RunResult> AwaitRunAsync(string algorithm, string requestId, CancellationToken cancellationToken, int pollIntervalSeconds = 1);
+    public Task<RunResult> AwaitRunAsync(string algorithm, string requestId, CancellationToken cancellationToken = default, int pollIntervalSeconds = 1);
 }

--- a/src/SnD.ApiClient/Crystal/Base/ICrystalClient.cs
+++ b/src/SnD.ApiClient/Crystal/Base/ICrystalClient.cs
@@ -36,5 +36,5 @@ public interface ICrystalClient
     /// <param name="cancellationToken">Cancellation token for the operation timeout.</param>
     /// <param name="pollIntervalSeconds">Poll interval to check for run results in seconds.</param>
     /// <returns>RunResult instance</returns>
-    public Task<RunResult> AwaitRunAsync(string algorithm, string requestId, CancellationToken cancellationToken, int pollIntervalSeconds);
+    public Task<RunResult> AwaitRunAsync(string algorithm, string requestId, CancellationToken cancellationToken, int pollIntervalSeconds = 1);
 }

--- a/src/SnD.ApiClient/Crystal/Base/ICrystalClient.cs
+++ b/src/SnD.ApiClient/Crystal/Base/ICrystalClient.cs
@@ -27,7 +27,9 @@ public interface ICrystalClient
     public Task<RunResult> GetResultAsync(string algorithm, string requestId, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Awaits a run until it completes with any result.
+    /// Awaits a run until it completes with any result or runs out of time set via cancellationToken.
+    /// For some cases this can return a failed result when the algorithm has not been actually executed, for example,
+    /// when a submission was lost.
     /// </summary>
     /// <param name="algorithm">Algorithm name</param>
     /// <param name="requestId">Request ID received form <see cref="CreateRunAsync"/></param>

--- a/src/SnD.ApiClient/Crystal/Base/ICrystalClient.cs
+++ b/src/SnD.ApiClient/Crystal/Base/ICrystalClient.cs
@@ -25,4 +25,14 @@ public interface ICrystalClient
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>RunResult instance</returns>
     public Task<RunResult> GetResultAsync(string algorithm, string requestId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Awaits a run until it completes with any result.
+    /// </summary>
+    /// <param name="algorithm">Algorithm name</param>
+    /// <param name="requestId">Request ID received form <see cref="CreateRunAsync"/></param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>RunResult instance</returns>
+    public Task<RunResult> AwaitRunAsync(string algorithm, string requestId,
+        CancellationToken cancellationToken = default);
 }

--- a/src/SnD.ApiClient/Crystal/CrystalClient.cs
+++ b/src/SnD.ApiClient/Crystal/CrystalClient.cs
@@ -62,7 +62,7 @@ public class CrystalClient : SndApiClient, ICrystalClient
     }
 
     /// <inheritdoc/>
-    public async Task<RunResult> AwaitRunAsync(string algorithm, string requestId, CancellationToken cancellationToken, int pollIntervalSeconds = 1)
+    public async Task<RunResult> AwaitRunAsync(string algorithm, string requestId, CancellationToken cancellationToken = default, int pollIntervalSeconds = 1)
     {
         var requestUri = new Uri(baseUri, new Uri($"algorithm/{this.apiVersion}/results/{algorithm}/requests/{requestId}", UriKind.Relative));
         var request = new HttpRequestMessage(HttpMethod.Get, requestUri);

--- a/src/SnD.ApiClient/Crystal/CrystalClient.cs
+++ b/src/SnD.ApiClient/Crystal/CrystalClient.cs
@@ -1,9 +1,12 @@
-﻿using System.Text;
+﻿using System.Net;
+using System.Text;
 using System.Text.Json;
 using SnD.ApiClient.Crystal.Models;
 using SnD.ApiClient.Crystal.Models.Base;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Polly;
+using Polly.Retry;
 using SnD.ApiClient.Base;
 using SnD.ApiClient.Boxer.Base;
 using SnD.ApiClient.Config;
@@ -15,6 +18,13 @@ public class CrystalClient : SndApiClient, ICrystalClient
 {
     private readonly Uri baseUri;
     private readonly string apiVersion;
+    private readonly AsyncRetryPolicy<HttpResponseMessage> awaitRetryPolicy;
+
+    private readonly RequestLifeCycleStage[] completedStages = new[]
+    {
+        RequestLifeCycleStage.FAILED, RequestLifeCycleStage.COMPLETED, RequestLifeCycleStage.DEADLINE_EXCEEDED,
+        RequestLifeCycleStage.SCHEDULING_TIMEOUT
+    };
 
     public CrystalClient(IOptions<CrystalClientOptions> crystalClientOptions, HttpClient httpClient,
         IJwtTokenExchangeProvider boxerConnector, ILogger<CrystalClient> logger) : base(httpClient, boxerConnector, logger)
@@ -23,6 +33,25 @@ public class CrystalClient : SndApiClient, ICrystalClient
                           throw new ArgumentNullException(nameof(CrystalClientOptions.ApiVersion));
         this.baseUri = new Uri(crystalClientOptions.Value.BaseUri
                        ?? throw new ArgumentNullException(nameof(CrystalClientOptions.BaseUri)));
+        // Crystal can return 404 in three cases:
+        // - Submission is not found
+        // - Submission is delayed
+        // - Submission was lost
+        // For the two latter ones we can wait a bit and see if the situation resolves.
+        this.awaitRetryPolicy = Policy
+            .HandleResult<HttpResponseMessage>(response => response.StatusCode == HttpStatusCode.NotFound)
+            .WaitAndRetryAsync(
+                retryCount: crystalClientOptions.Value.MaxRetries,
+                sleepDurationProvider: retryAttempt =>
+                {
+                    var jitter = new Random();
+                    return TimeSpan.FromMilliseconds(Math.Pow(2, retryAttempt) * 1000 + jitter.Next(0, 1000)) ;
+                },
+                onRetryAsync: (result, span, retryAttempt, _) =>
+                {
+                    this.logger.LogWarning("Server responded with 404 for the requested submission {uri} {retryAttempt} times. Will retry in {retryInterval} seconds.", result.Result.RequestMessage.RequestUri, retryAttempt, span.TotalSeconds);
+                    return Task.CompletedTask;
+                });
     }
 
     /// <inheritdoc/>
@@ -46,12 +75,41 @@ public class CrystalClient : SndApiClient, ICrystalClient
         return JsonSerializer.Deserialize<CreateRunResponse>(responseString, JsonSerializerOptions);
     }
 
-    public async Task<RunResult> GetResultAsync(string algorithm, string requestId, CancellationToken cancellationToken = default)
+    /// <inheritdoc/>
+    public Task<RunResult> GetResultAsync(string algorithm, string requestId, CancellationToken cancellationToken = default)
+    {
+        return this.GetResult(algorithm, requestId, cancellationToken);
+    }
+
+    private async Task<RunResult> GetResult(string algorithm, string requestId, CancellationToken cancellationToken = default)
     {
         var requestUri = new Uri(baseUri, new Uri($"algorithm/{this.apiVersion}/results/{algorithm}/requests/{requestId}", UriKind.Relative));
         var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
-        var response = await SendAuthenticatedRequestAsync(request, cancellationToken);
+        var response = await this.awaitRetryPolicy.ExecuteAsync(ct => SendAuthenticatedRequestAsync(request, ct), cancellationToken);
         response.EnsureSuccessStatusCode();
-        return JsonSerializer.Deserialize<RunResult>(await response.Content.ReadAsStreamAsync(), JsonSerializerOptions);
+        return JsonSerializer.Deserialize<RunResult>(await response.Content.ReadAsStreamAsync(), JsonSerializerOptions);        
+    }
+
+    /// <inheritdoc/>
+    public async Task<RunResult> AwaitRunAsync(string algorithm, string requestId, CancellationToken cancellationToken)
+    {
+        var requestUri = new Uri(baseUri, new Uri($"algorithm/{this.apiVersion}/results/{algorithm}/requests/{requestId}", UriKind.Relative));
+        do
+        {
+            using var cts = new CancellationTokenSource();
+            cts.CancelAfter(TimeSpan.FromSeconds(10));
+            var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+            var response =
+                await this.awaitRetryPolicy.ExecuteAsync(ct => SendAuthenticatedRequestAsync(request, ct), cts.Token);
+            var result = JsonSerializer.Deserialize<RunResult>(await response.Content.ReadAsStreamAsync(),
+                JsonSerializerOptions);
+            
+            if (this.completedStages.Contains(result.Status))
+            {
+                return result;
+            }
+        } while (!cancellationToken.IsCancellationRequested);
+        
+        return RunResult.LostSubmission(requestId);
     }
 }

--- a/src/SnD.ApiClient/Crystal/CrystalClient.cs
+++ b/src/SnD.ApiClient/Crystal/CrystalClient.cs
@@ -62,7 +62,7 @@ public class CrystalClient : SndApiClient, ICrystalClient
     }
 
     /// <inheritdoc/>
-    public async Task<RunResult> AwaitRunAsync(string algorithm, string requestId, CancellationToken cancellationToken, int pollIntervalSeconds)
+    public async Task<RunResult> AwaitRunAsync(string algorithm, string requestId, CancellationToken cancellationToken, int pollIntervalSeconds = 1)
     {
         var requestUri = new Uri(baseUri, new Uri($"algorithm/{this.apiVersion}/results/{algorithm}/requests/{requestId}", UriKind.Relative));
         var request = new HttpRequestMessage(HttpMethod.Get, requestUri);

--- a/src/SnD.ApiClient/Crystal/Models/Base/RequestLifecycleStage.cs
+++ b/src/SnD.ApiClient/Crystal/Models/Base/RequestLifecycleStage.cs
@@ -12,5 +12,6 @@ public enum RequestLifeCycleStage
     FAILED,
     SCHEDULING_TIMEOUT,
     DEADLINE_EXCEEDED,
-    THROTTLED
+    THROTTLED,
+    CLIENT_TIMEOUT
 }

--- a/src/SnD.ApiClient/Crystal/Models/Base/RunResult.cs
+++ b/src/SnD.ApiClient/Crystal/Models/Base/RunResult.cs
@@ -35,15 +35,14 @@ public record RunResult
             RunErrorMessage = "Submission has been lost or does not exist. Please retry it in a few seconds."
         };
     }
-
-    public static RunResult Pending(string requestId)
+    public static RunResult TimeoutSubmission(string requestId)
     {
         return new RunResult
         {
             RequestId = requestId,
-            Status = RequestLifeCycleStage.RUNNING,
+            Status = RequestLifeCycleStage.CLIENT_TIMEOUT,
             ResultUri = null,
-            RunErrorMessage = null
+            RunErrorMessage = "Submission timed out on the client side, but is still running on the server. Note that it might complete eventually, but the client has chosen to give up due to cancellation policy provided."
         };
-    }
+    }    
 }

--- a/src/SnD.ApiClient/Crystal/Models/Base/RunResult.cs
+++ b/src/SnD.ApiClient/Crystal/Models/Base/RunResult.cs
@@ -32,7 +32,7 @@ public record RunResult
             RequestId = requestId,
             Status = RequestLifeCycleStage.FAILED,
             ResultUri = null,
-            RunErrorMessage = "Submission has been lost. Please retry in a few seconds."
+            RunErrorMessage = "Submission has been lost or does not exist. Please retry it in a few seconds."
         };
     }
 

--- a/src/SnD.ApiClient/Crystal/Models/Base/RunResult.cs
+++ b/src/SnD.ApiClient/Crystal/Models/Base/RunResult.cs
@@ -2,7 +2,7 @@
 
 namespace SnD.ApiClient.Crystal.Models.Base;
 
-public class RunResult
+public record RunResult
 {
     /// <summary>
     /// Identifier of a request.
@@ -24,4 +24,26 @@ public class RunResult
     /// Error to be communicated to a client.
     /// </summary>
     public string RunErrorMessage { get; set; }
+
+    public static RunResult LostSubmission(string requestId)
+    {
+        return new RunResult
+        {
+            RequestId = requestId,
+            Status = RequestLifeCycleStage.FAILED,
+            ResultUri = null,
+            RunErrorMessage = "Submission has been lost. Please retry in a few seconds."
+        };
+    }
+
+    public static RunResult Pending(string requestId)
+    {
+        return new RunResult
+        {
+            RequestId = requestId,
+            Status = RequestLifeCycleStage.RUNNING,
+            ResultUri = null,
+            RunErrorMessage = null
+        };
+    }
 }

--- a/src/SnD.ApiClient/README.md
+++ b/src/SnD.ApiClient/README.md
@@ -68,3 +68,26 @@ To get a request status:
 ```csharp
     var runResult = await crystalConnector.GetResultAsync("algorithm-name", response.RequestId);
 ```
+
+To await the run and cancel using external timeout:
+```csharp
+   var response = await crystalConnector.CreateRunAsync(
+                "algorithm-name",
+                /* algorithm payload */,
+                /* algorithm configuration */,
+                CancellationToken.None
+       );
+  
+  using var cts = new CancellationTokenSource();
+  cts.CancelAfter(TimeSpan.FromMinutes(5);
+  var result = await crystalConnector.AwaitRunAsync(
+                "algorithm-name",
+                response.RequestId,
+                cts.Token
+  );
+  
+  if (result.Status == RequestLifeCycleStage.FAILED)
+  {
+      // do stuff
+  }
+```


### PR DESCRIPTION
Fixes #30 

## Scope

Implemented:
 - Added retry policy for 404 responses capped by max retries setting

Additional changes:
- Added `AwaitRunAsync` which handles 404 responses.

~~NB: WIP, should probably consider keeping GetResultAsync as-is~~ - DONE

## Checklist

- [x] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [x] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.