### PR TITLE
Create a method on crystal to get the underlying results from ResultsUri

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -40,5 +40,5 @@ jobs:
         run: |
           set -e
           version=$(git describe --tags --abbrev=7 | tr -d "v")
-          dotnet pack --configuration Release SnD.ApiClient.csproj
+          dotnet pack --configuration Release SnD.ApiClient.Azure.csproj
           dotnet nuget push "bin/Release/SnD.ApiClient.Azure.$version.nupkg" --source "github"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -40,6 +40,5 @@ jobs:
         run: |
           set -e
           version=$(git describe --tags --abbrev=7 | tr -d "v")
-          dotnet nuget add source --username USERNAME --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/SneaksAndData/index.json"
           dotnet pack --configuration Release SnD.ApiClient.csproj
           dotnet nuget push "bin/Release/SnD.ApiClient.Azure.$version.nupkg" --source "github"

--- a/src/SnD.ApiClient/Crystal/Base/ICrystalClient.cs
+++ b/src/SnD.ApiClient/Crystal/Base/ICrystalClient.cs
@@ -37,4 +37,15 @@ public interface ICrystalClient
     /// <param name="pollInterval">Poll interval to check for run results.</param>
     /// <returns>RunResult instance</returns>
     public Task<RunResult> AwaitRunAsync(string algorithm, string requestId, TimeSpan pollInterval, CancellationToken cancellationToken);
+    
+    /// <summary>
+    /// Reads the result of the run and converts it to the specified type.
+    /// </summary>
+    /// <param name="algorithm">Algorithm name</param>
+    /// <param name="requestId">Request ID received form <see cref="CreateRunAsync"/></param>
+    /// <param name="cancellationToken">Cancellation token for the operation timeout.</param>
+    /// <param name="converter">Function to convert bytes from results into TResult</param>
+    /// <typeparam name="TResult">Return type</typeparam>
+    /// <returns></returns>
+    public Task<TResult> GetResultAsync<TResult>(string algorithm, string requestId, Func<byte[], TResult> converter, CancellationToken cancellationToken = default);
 }

--- a/src/SnD.ApiClient/Crystal/Base/ICrystalClient.cs
+++ b/src/SnD.ApiClient/Crystal/Base/ICrystalClient.cs
@@ -39,7 +39,8 @@ public interface ICrystalClient
     public Task<RunResult> AwaitRunAsync(string algorithm, string requestId, TimeSpan pollInterval, CancellationToken cancellationToken);
     
     /// <summary>
-    /// Reads the result of the run and converts it to the specified type.
+    /// Reads the result of the run and converts it to the specified type using a specified converter function.
+    /// If the run is not completed yet or has failed, the method will return default value for the type.
     /// </summary>
     /// <param name="algorithm">Algorithm name</param>
     /// <param name="requestId">Request ID received form <see cref="CreateRunAsync"/></param>


### PR DESCRIPTION
## Scope

Implemented:
 - New method `crystalClient.GetResultAsync<TResult>(algorithm, requestId, (bytes=>...), ctx)` to retrieve results from a crystal run.

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.