### PR TITLE
Add image registry to AlgorithmConfiguration (already in crystal)

### DIFF
--- a/src/SnD.ApiClient/Crystal/Models/Base/AlgorithmConfiguration.cs
+++ b/src/SnD.ApiClient/Crystal/Models/Base/AlgorithmConfiguration.cs
@@ -9,6 +9,11 @@
         /// Container image used by this algorithm.
         /// </summary>
         public string ImageRepository { get; set; }
+        
+        /// <summary>
+        /// Container image registry used by this algorithm.
+        /// </summary>
+        public string ImageRegistry { get; set; }
 
         /// <summary>
         /// Image tag (version) used by this algorithm.


### PR DESCRIPTION
## Scope

Implemented:
 - Added `ImageRegistry` as part of `AlgorithmConfiguration` (already exists in [crystal repo](https://github.com/SneaksAndData/crystal/blob/2632fc45d558b1160c5c1c91d789ae99b294e65e/src/Crystal.Core/Models/V1/Base/AlgorithmConfiguration.cs#L20))

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.