### PR TITLE
Bump release version to 1.0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,5 +18,5 @@ jobs:
       - name: Create Release
         uses: SneaksAndData/github-actions/semver_release@v0.1.11
         with:
-          major_v: 0
-          minor_v: 1
+          major_v: 1
+          minor_v: 0


### PR DESCRIPTION
Part of https://github.com/SneaksAndData/nexus-sdk-go/issues/49

## Scope

Implemented:
 - This bumps the release version to 1.0

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.