### PR TITLE
Ensure successful status code check for token response

### DIFF
--- a/src/SnD.ApiClient/Boxer/BoxerTokenProvider.cs
+++ b/src/SnD.ApiClient/Boxer/BoxerTokenProvider.cs
@@ -54,6 +54,7 @@ public class BoxerTokenProvider : IJwtTokenExchangeProvider
                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", externalToken);
                return await httpClient.SendAsync(request, cancellationToken);
             });
+         response.EnsureSuccessStatusCode();
          this.token = await response.Content.ReadAsStringAsync(cancellationToken);
          this.logger.LogInformation("Received boxer token");
       }


### PR DESCRIPTION
This pull request makes a targeted improvement to the `GetTokenAsync` method in `BoxerTokenProvider.cs` by ensuring that HTTP requests for tokens only proceed if the response is successful.

- Reliability improvement:
  * Added a call to `response.EnsureSuccessStatusCode()` to throw an exception if the HTTP response is not successful, preventing the use of invalid or error responses when retrieving the boxer token.

## Checklist

- [ ] GitHub issue exists for this change.
- [ ] Unit tests added and they pass.
- [ ] Line Coverage is at least 80%.
- [ ] Review requested on `latest` commit.