### PR TITLE
fix: remove -x from set -euxo pipefail to prevent secret leakage

### DIFF
--- a/.github/workflows/publish-public.yaml
+++ b/.github/workflows/publish-public.yaml
@@ -41,7 +41,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
-          set -euxo pipefail
+          set -euo pipefail
           version=$(git describe --tags --abbrev=7 | tr -d "v")
           dotnet pack --configuration Release SnD.ApiClient.csproj
           
@@ -60,7 +60,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
-          set -euxo pipefail
+          set -euo pipefail
           version=$(git describe --tags --abbrev=7 | tr -d "v")
           dotnet pack --configuration Release SnD.ApiClient.Azure.csproj
           


### PR DESCRIPTION
## Summary

Removes the `-x` flag from `set -euxo pipefail` to prevent secrets from being printed in GitHub Actions logs.

The `-x` flag causes bash to print each command before executing it, which can expose secret values that are passed as environment variables or arguments.

## Related Issue

Closes SneaksAndData/terraform#7626

## Changes

- Replaced `set -euxo pipefail` with `set -euo pipefail` in affected workflow files
